### PR TITLE
[Refactor] Avoid multiple Jotai instances

### DIFF
--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -2,14 +2,13 @@
 
 import "./page.scss";
 
-import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import useSWR from "swr";
 
 import { Chart } from "@/components/Chart";
 import { Checkbox } from "@/components/Checkbox";
 import { FullScreen } from "@/components/FullScreen";
-import { Modal, modalAtom } from "@/components/Modal";
+import { Modal, useModal } from "@/components/Modal";
 import { fetcher } from "@/lib/swr";
 import type { ReasasPrefecturesResponse } from "@/types/resas";
 import {
@@ -18,7 +17,7 @@ import {
 } from "@/utils/fetcher/resas";
 
 export default function Page() {
-  const [, setIsModalOpen] = useAtom(modalAtom);
+  const [, setIsModalOpen] = useModal();
   const [newPref, setNewPref] = useState<PopulationChartData["pref"] | null>(
     null
   );

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,17 +1,24 @@
+import { Provider as JotaiProvider } from "jotai";
 import { ThemeProvider as NextThemeProvider } from "next-themes";
 
 /** @see {@link https://github.com/pacocoursey/next-themes} */
 
 export function Provider(props: {
   children: React.ReactNode;
+  jotaiProviderProps?: Omit<
+    React.ComponentProps<typeof JotaiProvider>,
+    "children"
+  >;
   nextThemeProviderProps?: Omit<
     React.ComponentProps<typeof NextThemeProvider>,
     "children"
   >;
 }) {
   return (
-    <NextThemeProvider {...props.nextThemeProviderProps}>
-      {props.children}
-    </NextThemeProvider>
+    <JotaiProvider {...props.jotaiProviderProps}>
+      <NextThemeProvider {...props.nextThemeProviderProps}>
+        {props.children}
+      </NextThemeProvider>
+    </JotaiProvider>
   );
 }

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -7,13 +7,15 @@ import { atom, useAtom } from "jotai";
 
 import { cn } from "@/utils/cn";
 
+const modalAtom = atom(false);
+
 /**
- * Jotai atom for modal state.
+ * Modal (Dialog) state hook.
  * ```tsx
- * const [isModalOpen, setIsModalOpen] = useAtom(modalAtom);
+ * const [isModalOpen, setIsModalOpen] = useModal();
  * ```
  */
-export const modalAtom = atom(false);
+export const useModal = () => useAtom(modalAtom);
 
 /**
  * Modal (Dialog) component.
@@ -33,7 +35,7 @@ export function Modal({
   children?: React.ReactNode;
   header?: React.ReactNode;
 }) {
-  const [isModalOpen, setIsModalOpen] = useAtom(modalAtom);
+  const [isModalOpen, setIsModalOpen] = useModal();
 
   return (
     <div

--- a/test/components/Modal.test.tsx
+++ b/test/components/Modal.test.tsx
@@ -1,8 +1,7 @@
 import "@testing-library/jest-dom";
 
-import { Modal, modalAtom } from "@components/Modal";
+import { Modal, useModal } from "@components/Modal";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { useAtom } from "jotai";
 import { beforeEach, describe, expect, test } from "vitest";
 
 /** Test component for Modal */
@@ -13,7 +12,7 @@ const ModalTest = ({
   children?: React.ReactNode;
   header?: React.ReactNode;
 }) => {
-  const [, setIsModalOpen] = useAtom(modalAtom);
+  const [, setIsModalOpen] = useModal();
   return (
     <>
       <Modal header={header}>{children}</Modal>


### PR DESCRIPTION
# Features

Avoid multiple Jotai instances.

```console
Detected multiple Jotai instances. It may cause unexpected behavior with the default store. https://github.com/pmndrs/jotai/discussions/2044
```

## Do

- Create a hook for modal component state
- Replace `useAtom` to the above hook
- Add Jotai provider in root layout

